### PR TITLE
account numbers for domestic post payments must be fixed sized

### DIFF
--- a/lib/payment_gen/ezag_records/domestic_post_account_record.rb
+++ b/lib/payment_gen/ezag_records/domestic_post_account_record.rb
@@ -27,11 +27,11 @@ module PaymentGen
       end
 
       def receiver_account_number
-        data[:receiver_account_number].gsub(/-/, '')
+        data[:receiver_account_number].gsub(/-/, '').ljust(9)
       end
 
       def end_beneficiary_account_number
-        data[:end_beneficiary_account_number]
+        (data[:end_beneficiary_account_number] || '').ljust(35)
       end
 
       def receiver_name

--- a/spec/lib/payment_gen/ezag_records/domestic_post_account_record_spec.rb
+++ b/spec/lib/payment_gen/ezag_records/domestic_post_account_record_spec.rb
@@ -26,12 +26,24 @@ describe PaymentGen::EZAGRecords::DomesticPostAccountRecord do
       EZAGFactory.create_domestic_post_account_record(:land_code => 'CH').land_code.should == 'CH'
     end
 
-    it "should set the account number of the receiver" do
-      EZAGFactory.create_domestic_post_account_record(:receiver_account_number => '38-847394-5').receiver_account_number.should == '388473945'
+    describe "#receiver_account_number" do
+      it "should set the account number of the receiver" do
+        EZAGFactory.create_domestic_post_account_record(:receiver_account_number => '38-847394-5').receiver_account_number.should == '388473945'
+      end
+
+      it "adds spaces up to 9 characters" do
+        EZAGFactory.create_domestic_post_account_record(:receiver_account_number => '38-8394-5').receiver_account_number.should == '3883945  '
+      end
     end
 
-    it "should set the account number of the end beneficiary" do
-      EZAGFactory.create_domestic_post_account_record(:end_beneficiary_account_number => 'CH8774658193857463527').end_beneficiary_account_number.should == 'CH8774658193857463527'
+    describe "#end_beneficiary_account_number" do
+      it "should set the account number of the end beneficiary" do
+        EZAGFactory.create_domestic_post_account_record(:end_beneficiary_account_number => 'CH8774658193857463527').end_beneficiary_account_number.should == "CH8774658193857463527#{' ' * 14}"
+      end
+
+      it "is not required" do
+        EZAGFactory.create_domestic_post_account_record(:end_beneficiary_account_number => nil).end_beneficiary_account_number.should == "#{' ' * 35}"
+      end
     end
 
     it "should set the receivers name" do
@@ -60,7 +72,7 @@ describe PaymentGen::EZAGRecords::DomesticPostAccountRecord do
     it "returns the domestic post account record" do
       record = EZAGFactory.create_domestic_post_account_record(:due_date => '24.9.1928', :account_number => '48-387493-2', :source_currency => 'CHF', :payment_amount => 803.50, :target_currency => 'CHF', :land_code => 'CH', :receiver_account_number => '95-847392-9', :end_beneficiary_account_number => 'CH8794857239482758715', :receiver_name => 'Spöri Enterprises', :additional_identification => 'z.H. Fritz Knall', :receiver_street => 'Packweg 9', :receiver_zip_code => '1843', :receiver_city => 'Genf')
       record.transaction_number = 1
-      record.to_s.should == '03628092400000148387493248387493201220000010000000CHF0000000080350 CHFCH958473929      CH8794857239482758715Spöri Enterprises                  z.H. Fritz Knall                   Packweg 9                          1843      Genf                     ' + (' ' * 438)
+      record.to_s.should == '03628092400000148387493248387493201220000010000000CHF0000000080350 CHFCH958473929      CH8794857239482758715              Spöri Enterprises                  z.H. Fritz Knall                   Packweg 9                          1843      Genf                     ' + (' ' * 438)
     end
   end
 


### PR DESCRIPTION
- the account number must be fixed sized up to 9 characters
- the end beneficiary account number must be fixed sized up to 35 characters
